### PR TITLE
Enhance error handling

### DIFF
--- a/integration-tests/src/test/java/io/github/alexshamrai/integration/BaseIntegrationTest.java
+++ b/integration-tests/src/test/java/io/github/alexshamrai/integration/BaseIntegrationTest.java
@@ -1,10 +1,36 @@
 package io.github.alexshamrai.integration;
 
-import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.extension.ExtendWith;
 import io.github.alexshamrai.jupiter.CtrfExtension;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 @ExtendWith(CtrfExtension.class)
-@Tag("integration")
 public abstract class BaseIntegrationTest {
+
+    @BeforeAll
+    static void beforeAll() {
+        System.out.println("BaseIntegrationTest beforeAll()");
+        // throw new RuntimeException("BaseIntegrationTest beforeAll() exception");
+    }
+
+    @AfterAll
+    static void afterAll() {
+        System.out.println("BaseIntegrationTest afterAll()");
+        // throw new RuntimeException("BaseIntegrationTest afterAll() exception");
+    }
+
+    @BeforeEach
+    void beforeEach() {
+        System.out.println("BaseIntegrationTest beforeEach()");
+        // throw new RuntimeException("BaseIntegrationTest beforeEach() exception");
+    }
+
+    @AfterEach
+    void afterEach() {
+        System.out.println("BaseIntegrationTest afterEach()");
+        // throw new RuntimeException("BaseIntegrationTest afterEach() exception");
+    }
 }

--- a/src/main/java/io/github/alexshamrai/FileWriter.java
+++ b/src/main/java/io/github/alexshamrai/FileWriter.java
@@ -1,7 +1,8 @@
-package io.github.alexshamrai.util;
+package io.github.alexshamrai;
 
 import io.github.alexshamrai.ctrf.model.CtrfJson;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.github.alexshamrai.util.ConfigReader;
 import lombok.RequiredArgsConstructor;
 
 import java.io.File;
@@ -20,8 +21,7 @@ public class FileWriter {
         try {
             objectMapper.writeValue(new File(filePath), ctrfJson);
         } catch (IOException e) {
-            //TODO: add logging, consider get rid of checked exception
-            throw new RuntimeException("Failed to write results to file: " + filePath, e);
+            System.err.println("Failed to write results to file: " + filePath + " - " + e.getMessage());
         }
     }
 }

--- a/src/main/java/io/github/alexshamrai/SuiteExecutionErrorHandler.java
+++ b/src/main/java/io/github/alexshamrai/SuiteExecutionErrorHandler.java
@@ -1,0 +1,38 @@
+package io.github.alexshamrai;
+
+import io.github.alexshamrai.ctrf.model.Test;
+import io.github.alexshamrai.ctrf.model.Test.TestStatus;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+import java.util.Optional;
+
+public class SuiteExecutionErrorHandler {
+
+    private final TestProcessor testProcessor;
+
+    public SuiteExecutionErrorHandler(TestProcessor testProcessor) {
+        this.testProcessor = testProcessor;
+    }
+
+    public Optional<Test> handleInitializationError(ExtensionContext context, long testRunStartTime, long testRunStopTime) {
+        return handleError(context, "Initialization Error", testRunStartTime, testRunStopTime);
+    }
+
+    public Optional<Test> handleExecutionError(ExtensionContext context, long testRunStartTime, long testRunStopTime) {
+        return handleError(context, "Execution Error", testRunStartTime, testRunStopTime);
+    }
+
+    private Optional<Test> handleError(ExtensionContext context, String errorName, long testRunStartTime, long testRunStopTime) {
+        return context.getExecutionException().map(cause -> {
+            var failureTest = Test.builder()
+                .name(errorName)
+                .status(TestStatus.FAILED)
+                .start(testRunStartTime)
+                .stop(testRunStopTime)
+                .duration(testRunStopTime - testRunStartTime)
+                .build();
+            testProcessor.setFailureDetails(failureTest, cause);
+            return failureTest;
+        });
+    }
+}

--- a/src/main/java/io/github/alexshamrai/TestProcessor.java
+++ b/src/main/java/io/github/alexshamrai/TestProcessor.java
@@ -1,4 +1,4 @@
-package io.github.alexshamrai.util;
+package io.github.alexshamrai;
 
 import io.github.alexshamrai.ctrf.model.Test;
 import io.github.alexshamrai.model.TestDetails;

--- a/src/main/java/io/github/alexshamrai/jupiter/TestRunExtension.java
+++ b/src/main/java/io/github/alexshamrai/jupiter/TestRunExtension.java
@@ -12,7 +12,12 @@ public interface TestRunExtension extends BeforeAllCallback {
             .getOrComputeIfAbsent(this.getClass(),
                 k -> {
                     beforeAllTests(context);
-                    return (ExtensionContext.Store.CloseableResource) this::afterAllTests;
+                    return new ExtensionContext.Store.CloseableResource() {
+                        @Override
+                        public void close() {
+                            afterAllTests(context);
+                        }
+                    };
                 });
     }
 
@@ -20,7 +25,7 @@ public interface TestRunExtension extends BeforeAllCallback {
 
     }
 
-    default void afterAllTests() {
+    default void afterAllTests(ExtensionContext context) {
 
     }
 }

--- a/src/main/java/io/github/alexshamrai/util/SummaryCreator.java
+++ b/src/main/java/io/github/alexshamrai/util/SummaryCreator.java
@@ -7,7 +7,7 @@ import java.util.List;
 
 public class SummaryCreator {
 
-    public Summary createSummary(List<Test> tests, long startTime, long stopTime) {
+    public static Summary createSummary(List<Test> tests, long startTime, long stopTime) {
         return Summary.builder()
             .tests(tests.size())
             .passed((int) tests.stream().filter(t -> t.getStatus() == Test.TestStatus.PASSED).count())


### PR DESCRIPTION
Refine error handling procedures in `CtrfExtension`, in order to handle BeforeAll and AfterAll test failures The error handling methods were shifted to a newly created `SuiteExecutionErrorHandler` class. This promotes better maintainability, encapsulating the error handling logic and supporting the principle of single responsibility.