### PR TITLE
Update CTRF reporting to use GitHub Test Reporter action

### DIFF
--- a/.github/workflows/check-ctrf.yml
+++ b/.github/workflows/check-ctrf.yml
@@ -29,8 +29,10 @@ jobs:
       - name: Run integration tests
         run: ./gradlew :integration-tests:test -Dthreads=${{ github.event.inputs.threads }}
 
-      - name: Run CTRF annotations
-        run: npx github-actions-ctrf integration-tests/build/test-results/test/ctrf-report.json
+      - name: Publish CTRF Test Report
+        uses: ctrf-io/github-test-reporter@v1
+        with:
+          report-path: 'integration-tests/build/test-results/test/ctrf-report.json'
         if: always()
 
       - name: Upload test results

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,8 @@ jobs:
       - name: Run unit tests
         run: ./gradlew test -x :integration-tests:test
 
-      - name: Run CTRF annotations
-        run: npx github-actions-ctrf build/test-results/test/ctrf-report.json
+      - name: Publish CTRF Test Report
+        uses: ctrf-io/github-test-reporter@v1
+        with:
+          report-path: 'build/test-results/test/ctrf-report.json'
         if: always()


### PR DESCRIPTION
Replaced manual CTRF annotation commands with the `ctrf-io/github-test-reporter` action for consistency and better maintainability. This enhances the workflow by simplifying configuration and automating test report publishing.