### PR TITLE
Update CTRF test reporter to version 1.0.3

### DIFF
--- a/.github/workflows/check-ctrf.yml
+++ b/.github/workflows/check-ctrf.yml
@@ -30,7 +30,7 @@ jobs:
         run: ./gradlew :integration-tests:test -Dthreads=${{ github.event.inputs.threads }}
 
       - name: Publish CTRF Test Report
-        uses: ctrf-io/github-test-reporter@v1.0.1
+        uses: ctrf-io/github-test-reporter@v1.0.3
         with:
           report-path: 'integration-tests/build/test-results/test/ctrf-report.json'
 
@@ -45,7 +45,7 @@ jobs:
           previous-results-max: 10
           artifact-name: 'ctrf-report'
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         if: always()
 
       - name: Upload test results

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
         run: ./gradlew test -x :integration-tests:test
 
       - name: Publish CTRF Test Report
-        uses: ctrf-io/github-test-reporter@v1
+        uses: ctrf-io/github-test-reporter@v1.0.3
         with:
           report-path: 'build/test-results/test/ctrf-report.json'
         if: always()


### PR DESCRIPTION
Upgraded the GitHub action for the CTRF test reporter to v1.0.3 for improved reliability and potential bug fixes. This ensures compatibility with the latest features and fixes of the action.