### PR TITLE
chore: update dependencies and tools to latest versions

### DIFF
--- a/.github/workflows/check-ctrf.yml
+++ b/.github/workflows/check-ctrf.yml
@@ -30,7 +30,7 @@ jobs:
         run: ./gradlew :integration-tests:test -Dthreads=${{ github.event.inputs.threads }}
 
       - name: Publish CTRF Test Report
-        uses: ctrf-io/github-test-reporter@v1.0.3
+        uses: ctrf-io/github-test-reporter@v1.0.13
         with:
           report-path: 'integration-tests/build/test-results/test/ctrf-report.json'
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
         run: ./gradlew test -x :integration-tests:test
 
       - name: Publish CTRF Test Report
-        uses: ctrf-io/github-test-reporter@v1.0.3
+        uses: ctrf-io/github-test-reporter@v1.0.13
         with:
           report-path: 'ctrf-report.json'
         if: always()

--- a/build.gradle
+++ b/build.gradle
@@ -16,10 +16,10 @@ repositories {
 
 ext {
     junitVersion = '5.11.3'
-    lombokVersion = '1.18.36'
-    jaksonVersion = '2.18.2'
+    lombokVersion = '1.18.38'
+    jaksonVersion = '2.18.3'
     ownerVersion = '1.0.12'
-    mockitoVersion = '5.15.2'
+    mockitoVersion = '5.17.0'
     assertjVersion = '3.27.3'
 }
 
@@ -40,7 +40,7 @@ test {
 }
 
 checkstyle {
-    toolVersion = '10.21.0'
+    toolVersion = '10.23.0'
     configFile = file("${project.rootDir}/config/checkstyle/checkstyle.xml")
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
Updated Gradle wrapper to 8.13 and bumped versions for lombok, jackson, mockito, and checkstyle. Also upgraded the GitHub Actions CTRF test reporter from v1.0.3 to v1.0.13 for improved compatibility and fixes.