### PR TITLE
feat: add threadId to Extra in CTRF scheme

### DIFF
--- a/src/main/java/io/github/alexshamrai/TestProcessor.java
+++ b/src/main/java/io/github/alexshamrai/TestProcessor.java
@@ -1,6 +1,7 @@
 package io.github.alexshamrai;
 
 import io.github.alexshamrai.config.ConfigReader;
+import io.github.alexshamrai.ctrf.model.Extra;
 import io.github.alexshamrai.ctrf.model.Test;
 import io.github.alexshamrai.model.TestDetails;
 import lombok.RequiredArgsConstructor;
@@ -33,6 +34,13 @@ public class TestProcessor {
             .start(details.getStartTime())
             .stop(stopTime)
             .duration(stopTime - details.getStartTime())
+            .extra(createExtraWithThreadId())
+            .build();
+    }
+
+    private Extra createExtraWithThreadId() {
+        return Extra.builder()
+            .threadId(Thread.currentThread().getName())
             .build();
     }
 }

--- a/src/main/java/io/github/alexshamrai/ctrf/model/Extra.java
+++ b/src/main/java/io/github/alexshamrai/ctrf/model/Extra.java
@@ -16,4 +16,5 @@ import java.util.Map;
 public class Extra {
 
     private Map<String, Object> customData;
+    private String threadId;
 }

--- a/src/test/java/io/github/alexshamrai/TestProcessorTest.java
+++ b/src/test/java/io/github/alexshamrai/TestProcessorTest.java
@@ -91,4 +91,27 @@ public class TestProcessorTest extends BaseTest {
         assertEquals(stopTime, result.getStop());
         assertEquals(1000, result.getDuration());
     }
+
+    @org.junit.jupiter.api.Test
+    void createTest_setsThreadIdInExtra() {
+        var displayName = "Test Display Name";
+        var tags = new HashSet<>(Arrays.asList("tag1", "tag2"));
+        var filePath = "path/to/test/file.java";
+        var startTime = System.currentTimeMillis();
+        var stopTime = startTime + 1000;
+
+        var details = TestDetails.builder()
+            .tags(tags)
+            .filePath(filePath)
+            .startTime(startTime)
+            .build();
+
+        when(extensionContext.getDisplayName()).thenReturn(displayName);
+
+        var result = testProcessor.createTest(extensionContext, details, stopTime);
+
+        assertNotNull(result.getExtra());
+        assertNotNull(result.getExtra().getThreadId());
+        assertEquals(Thread.currentThread().getName(), result.getExtra().getThreadId());
+    }
 }


### PR DESCRIPTION
Introduced a threadId field in the Extra class to track the current thread's name. Updated Test creation to populate Extra with threadId and added corresponding unit test to verify the functionality.