### PR TITLE
refactor: move threadId from Extra to Test model

### DIFF
--- a/src/main/java/io/github/alexshamrai/TestProcessor.java
+++ b/src/main/java/io/github/alexshamrai/TestProcessor.java
@@ -1,7 +1,6 @@
 package io.github.alexshamrai;
 
 import io.github.alexshamrai.config.ConfigReader;
-import io.github.alexshamrai.ctrf.model.Extra;
 import io.github.alexshamrai.ctrf.model.Test;
 import io.github.alexshamrai.model.TestDetails;
 import lombok.RequiredArgsConstructor;
@@ -61,20 +60,6 @@ public class TestProcessor {
             .start(details.getStartTime())
             .stop(stopTime)
             .duration(stopTime - details.getStartTime())
-            .extra(createExtraWithThreadId())
-            .build();
-    }
-
-    /**
-     * Creates an Extra object containing the current thread ID.
-     * 
-     * <p>Thread ID information can be useful for diagnosing test execution issues,
-     * especially in parallel test environments.</p>
-     *
-     * @return an Extra object containing the current thread ID
-     */
-    private Extra createExtraWithThreadId() {
-        return Extra.builder()
             .threadId(Thread.currentThread().getName())
             .build();
     }

--- a/src/main/java/io/github/alexshamrai/ctrf/model/Extra.java
+++ b/src/main/java/io/github/alexshamrai/ctrf/model/Extra.java
@@ -16,5 +16,4 @@ import java.util.Map;
 public class Extra {
 
     private Map<String, Object> customData;
-    private String threadId;
 }

--- a/src/main/java/io/github/alexshamrai/ctrf/model/Test.java
+++ b/src/main/java/io/github/alexshamrai/ctrf/model/Test.java
@@ -36,6 +36,7 @@ public class Test {
     private String browser;
     private String device;
     private String screenshot;
+    private String threadId;
     private Map<String, Object> parameters;
     private List<Step> steps;
     private Extra extra;

--- a/src/test/java/io/github/alexshamrai/TestProcessorTest.java
+++ b/src/test/java/io/github/alexshamrai/TestProcessorTest.java
@@ -93,7 +93,7 @@ public class TestProcessorTest extends BaseTest {
     }
 
     @org.junit.jupiter.api.Test
-    void createTest_setsThreadIdInExtra() {
+    void createTest_setsThreadId() {
         var displayName = "Test Display Name";
         var tags = new HashSet<>(Arrays.asList("tag1", "tag2"));
         var filePath = "path/to/test/file.java";
@@ -110,8 +110,7 @@ public class TestProcessorTest extends BaseTest {
 
         var result = testProcessor.createTest(extensionContext, details, stopTime);
 
-        assertNotNull(result.getExtra());
-        assertNotNull(result.getExtra().getThreadId());
-        assertEquals(Thread.currentThread().getName(), result.getExtra().getThreadId());
+        assertNotNull(result.getThreadId());
+        assertEquals(Thread.currentThread().getName(), result.getThreadId());
     }
 }


### PR DESCRIPTION
Refactored the handling of threadId by migrating it from the Extra class to the Test model. Change is related to the schema update