### PR TITLE
fix(deps): update dependencies and GitHub actions

### DIFF
--- a/.github/workflows/check-ctrf.yml
+++ b/.github/workflows/check-ctrf.yml
@@ -30,7 +30,7 @@ jobs:
         run: ./gradlew :integration-tests:test -Dthreads=${{ github.event.inputs.threads }}
 
       - name: Publish CTRF Test Report
-        uses: ctrf-io/github-test-reporter@v1.0.13
+        uses: ctrf-io/github-test-reporter@v1.0.14
         with:
           report-path: 'integration-tests/build/test-results/test/ctrf-report.json'
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
         run: ./gradlew test -x :integration-tests:test
 
       - name: Publish CTRF Test Report
-        uses: ctrf-io/github-test-reporter@v1.0.13
+        uses: ctrf-io/github-test-reporter@v1.0.14
         with:
           report-path: 'ctrf-report.json'
         if: always()

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ plugins {
     id 'java'
     id 'signing'
     id 'checkstyle'
-    id 'com.vanniktech.maven.publish' version '0.30.0'
+    id 'com.vanniktech.maven.publish' version '0.31.0'
 }
 
 group = 'io.github.alexshamrai'


### PR DESCRIPTION
Bump `ctrf-io/github-test-reporter` to v1.0.14 and `com.vanniktech.maven.publish` to v0.31.0. These updates ensure compatibility and include the latest improvements for test reporting and publishing tasks.