### PR TITLE
feat: add startup duration calculation to summary extra object

### DIFF
--- a/integration-tests/src/test/resources/ctrf.properties
+++ b/integration-tests/src/test/resources/ctrf.properties
@@ -1,5 +1,6 @@
 ctrf.report.path=build/test-results/ctrf-report.json
 ctrf.max.message.length=300
+ctrf.calculate.startup.duration=true
 
 junit.version=4.44
 

--- a/src/main/java/io/github/alexshamrai/CtrfJsonComposer.java
+++ b/src/main/java/io/github/alexshamrai/CtrfJsonComposer.java
@@ -23,6 +23,7 @@ public class CtrfJsonComposer {
 
     private static final String TOOL_NAME = "JUnit";
     private final ConfigReader configReader;
+    private final StartupDurationProcessor startupDurationProcessor;
 
     /**
      * Generates a complete CTRF JSON object containing test results and metadata.
@@ -33,6 +34,10 @@ public class CtrfJsonComposer {
      *         reportFormat (set to "CTRF") and specVersion (set to "0.0.0")
      */
     public CtrfJson generateCtrfJson(Summary summary, List<Test> tests) {
+        if (configReader.calculateStartupDuration()) {
+            startupDurationProcessor.processStartupDuration(summary, tests);
+        }
+
         var results = Results.builder()
             .tool(composeTool())
             .summary(summary)

--- a/src/main/java/io/github/alexshamrai/StartupDurationProcessor.java
+++ b/src/main/java/io/github/alexshamrai/StartupDurationProcessor.java
@@ -1,0 +1,58 @@
+package io.github.alexshamrai;
+
+import io.github.alexshamrai.ctrf.model.Extra;
+import io.github.alexshamrai.ctrf.model.Summary;
+import io.github.alexshamrai.ctrf.model.Test;
+import lombok.RequiredArgsConstructor;
+
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Processor responsible for calculating and setting startup duration in test results.
+ * <p>
+ * This class calculates the startup duration as the difference between the summary start time
+ * and the first test start time, then adds it to the summary's extra data.
+ */
+@RequiredArgsConstructor
+public class StartupDurationProcessor {
+
+    /**
+     * Processes and adds test suite startup duration to the summary if applicable.
+     * <p>
+     * Calculates startup duration as the difference between the earliest test start time and
+     * summary start time, then adds it to the summary's extra data.
+     *
+     * @param summary the test execution summary
+     * @param tests   the list of test results
+     */
+    public void processStartupDuration(Summary summary, List<Test> tests) {
+        if (summary == null || tests.isEmpty()) {
+            return;
+        }
+
+        var firstTestStart = findStartTimeOfTheFirstTest(tests);
+        if (firstTestStart != null && summary.getStart() > 0) {
+            long startupDuration = firstTestStart - summary.getStart();
+            var extra = getExtraObject(summary);
+            extra.setStartupDuration(startupDuration);
+        }
+    }
+
+    private Extra getExtraObject(Summary summary) {
+        Extra extra = summary.getExtra();
+        if (extra == null) {
+            extra = new Extra();
+            summary.setExtra(extra);
+        }
+        return extra;
+    }
+
+    private Long findStartTimeOfTheFirstTest(List<Test> tests) {
+        return tests.stream()
+            .map(Test::getStart)
+            .filter(Objects::nonNull)
+            .min(Long::compareTo)
+            .orElse(null);
+    }
+}

--- a/src/main/java/io/github/alexshamrai/config/ConfigReader.java
+++ b/src/main/java/io/github/alexshamrai/config/ConfigReader.java
@@ -93,4 +93,8 @@ public class ConfigReader {
     public String getTestEnvironment() {
         return config.testEnvironment();
     }
+
+    public boolean calculateStartupDuration() {
+        return config.calculateStartupDuration();
+    }
 }

--- a/src/main/java/io/github/alexshamrai/config/CtrfConfig.java
+++ b/src/main/java/io/github/alexshamrai/config/CtrfConfig.java
@@ -77,4 +77,8 @@ public interface CtrfConfig extends Config {
 
     @Key("ctrf.test.environment")
     String testEnvironment();
+
+    @Key("ctrf.calculate.startup.duration")
+    @DefaultValue("false")
+    boolean calculateStartupDuration();
 }

--- a/src/main/java/io/github/alexshamrai/ctrf/model/Extra.java
+++ b/src/main/java/io/github/alexshamrai/ctrf/model/Extra.java
@@ -1,3 +1,4 @@
+
 package io.github.alexshamrai.ctrf.model;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
@@ -16,4 +17,5 @@ import java.util.Map;
 public class Extra {
 
     private Map<String, Object> customData;
+    private Long startupDuration;
 }

--- a/src/main/java/io/github/alexshamrai/jupiter/CtrfExtension.java
+++ b/src/main/java/io/github/alexshamrai/jupiter/CtrfExtension.java
@@ -2,6 +2,7 @@ package io.github.alexshamrai.jupiter;
 
 import io.github.alexshamrai.CtrfJsonComposer;
 import io.github.alexshamrai.CtrfReportFileService;
+import io.github.alexshamrai.StartupDurationProcessor;
 import io.github.alexshamrai.SuiteExecutionErrorHandler;
 import io.github.alexshamrai.TestProcessor;
 import io.github.alexshamrai.config.ConfigReader;
@@ -57,7 +58,8 @@ public class CtrfExtension implements TestRunExtension, BeforeEachCallback, Afte
         this.ctrfReportFileService = new CtrfReportFileService(configReader);
         this.testProcessor = new TestProcessor(configReader);
         this.suiteExecutionErrorHandler = new SuiteExecutionErrorHandler(testProcessor);
-        this.ctrfJsonComposer = new CtrfJsonComposer(configReader);
+        var startupDurationProcessor = new StartupDurationProcessor();
+        this.ctrfJsonComposer = new CtrfJsonComposer(configReader, startupDurationProcessor);
     }
 
     @Override

--- a/src/test/java/io/github/alexshamrai/StartupDurationProcessorTest.java
+++ b/src/test/java/io/github/alexshamrai/StartupDurationProcessorTest.java
@@ -1,0 +1,109 @@
+
+package io.github.alexshamrai;
+
+import io.github.alexshamrai.ctrf.model.Extra;
+import io.github.alexshamrai.ctrf.model.Summary;
+import io.github.alexshamrai.ctrf.model.Test;
+import org.junit.jupiter.api.BeforeEach;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+public class StartupDurationProcessorTest extends BaseTest {
+
+    private StartupDurationProcessor processor;
+
+    @BeforeEach
+    void setUp() {
+        processor = new StartupDurationProcessor();
+    }
+
+    @org.junit.jupiter.api.Test
+    void testProcessStartupDurationWithValidData() {
+        long summaryStartTime = 2000L;
+        var summary = Summary.builder()
+            .start(summaryStartTime)
+            .build();
+
+        long firstTestStartTime = 5000L;
+        long secondTestStartTime = 6000L;
+        var tests = List.of(
+            Test.builder().start(secondTestStartTime).build(),
+            Test.builder().start(firstTestStartTime).build()
+        );
+
+        long expectedStartupDuration = 3000L;
+
+        processor.processStartupDuration(summary, tests);
+
+        assertNotNull(summary.getExtra());
+        assertEquals(expectedStartupDuration, summary.getExtra().getStartupDuration());
+    }
+
+    @org.junit.jupiter.api.Test
+    void testProcessStartupDurationWithNullSummary() {
+        var tests = List.of(Test.builder().start(1000L).build());
+
+        processor.processStartupDuration(null, tests);
+
+        // No exception should be thrown, method should handle null gracefully
+    }
+
+    @org.junit.jupiter.api.Test
+    void testProcessStartupDurationWithEmptyTests() {
+        var summary = Summary.builder().start(5000L).build();
+        List<Test> tests = Collections.emptyList();
+
+        processor.processStartupDuration(summary, tests);
+
+        assertNull(summary.getExtra());
+    }
+
+    @org.junit.jupiter.api.Test
+    void testProcessStartupDurationWithTestsWithoutStartTime() {
+        var summary = Summary.builder().start(5000L).build();
+        var tests = List.of(
+            Test.builder().build(),
+            Test.builder().build()
+        );
+
+        processor.processStartupDuration(summary, tests);
+
+        assertNull(summary.getExtra());
+    }
+
+    @org.junit.jupiter.api.Test
+    void testProcessStartupDurationWithSummaryZeroStartTime() {
+        var summary = Summary.builder().start(0L).build();
+        var tests = List.of(Test.builder().start(1000L).build());
+
+        processor.processStartupDuration(summary, tests);
+
+        assertNull(summary.getExtra());
+    }
+
+    @org.junit.jupiter.api.Test
+    void testProcessStartupDurationWithExistingExtra() {
+        var summary = Summary.builder()
+            .start(2000L)
+            .extra(Extra.builder()
+                .customData(new HashMap<>(Map.of("existingKey", "existingValue")))
+                .build())
+            .build();
+
+        var tests = List.of(Test.builder().start(5000L).build());
+
+        processor.processStartupDuration(summary, tests);
+
+        assertNotNull(summary.getExtra());
+        assertEquals(3000L, summary.getExtra().getStartupDuration());
+        assertNotNull(summary.getExtra().getCustomData());
+        assertEquals("existingValue", summary.getExtra().getCustomData().get("existingKey"));
+    }
+}


### PR DESCRIPTION
- Add configuration option to enable startup duration calculation
- Calculate startup duration as difference between summary start and first test start
- Store startup duration in summary's extra custom data
- Add StartupDurationProcessor to handle calculation logic
- Include comprehensive test coverage for new functionality

```
   "summary": {
      "tests": 20,
      "passed": 13,
      "failed": 5,
      "pending": 0,
      "skipped": 2,
      "other": 0,
      "start": 1752236674455,
      "stop": 1752236683658,
      "extra": {
        "startupDuration": 11
      }
    }
```