### PR TITLE
chore: upgrade CTRF GitHub action version to v1.0.22

### DIFF
--- a/.github/workflows/check-ctrf.yml
+++ b/.github/workflows/check-ctrf.yml
@@ -39,7 +39,7 @@ jobs:
         if: always()
 
       - name: Publish CTRF Test Report
-        uses: ctrf-io/github-test-reporter@v1.0.18
+        uses: ctrf-io/github-test-reporter@v1.0.22
         with:
           report-path: 'integration-tests/build/test-results/ctrf-report.json'
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
         run: ./gradlew test -x :integration-tests:test
 
       - name: Publish CTRF Test Report
-        uses: ctrf-io/github-test-reporter@v1.0.18
+        uses: ctrf-io/github-test-reporter@v1.0.22
         with:
           report-path: 'ctrf-report.json'
         if: always()


### PR DESCRIPTION
Updated the `ctrf-io/github-test-reporter` action from v1.0.18 to v1.0.22 in workflow files. Ensures compatibility with the latest features and fixes provided by the action.