### PR TITLE
fix: improve integration tests, get rid of static hardcoded values on ci

### DIFF
--- a/.github/workflows/check-ctrf.yml
+++ b/.github/workflows/check-ctrf.yml
@@ -34,8 +34,8 @@ jobs:
           ./gradlew :integration-tests:validateCtrfReport \
           -Dthreads=${{ github.event_name == 'workflow_dispatch' && github.event.inputs.threads || '2' }} \
           -Dctrf.build.name=system-build \
-          -Dctrf.build.number=789 \
-          -Dctrf.build.url=http://system.example.com/build/
+          -Dctrf.build.number=${{ github.run_number }} \
+          -Dctrf.build.url=https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }} \
         if: always()
 
       - name: Publish CTRF Test Report

--- a/integration-tests/INTEGRATION_TESTS.md
+++ b/integration-tests/INTEGRATION_TESTS.md
@@ -135,6 +135,13 @@ The integration tests support parallel execution through the `threads` system pr
 
 This configures JUnit to run tests concurrently, which helps verify that the CTRF extension correctly handles parallel test execution.
 
+## Run tests exactly as in CI
+
+To run the integration tests exactly as in CI, in order to verify all the parameters processing locally(dynamic parameters, like build.number and build.url are hardcoded here):
+```bash
+./gradlew clean :integration-tests:validateCtrfReport -Dthreads=2 -Dctrf.build.name=system-build -Dctrf.build.number=777 -Dctrf.build.url=https://github.com/alexshamrai/junit-ctrf-extension/actions/runs/12345678
+```
+
 ## Adding New Integration Tests
 
 To add new test scenarios:

--- a/integration-tests/src/test/java/io/github/alexshamrai/integration/CtrfLogicTest.java
+++ b/integration-tests/src/test/java/io/github/alexshamrai/integration/CtrfLogicTest.java
@@ -149,11 +149,11 @@ public class CtrfLogicTest {
             .as("Build name should match the value passed via -Dctrf.build.name")
             .isEqualTo("system-build");
         assertThat(environment.getBuildNumber())
-            .as("Build number should match the value passed via -Dctrf.build.number")
-            .isEqualTo("789");
+            .as("Build number should be numeric")
+            .matches("\\d+");
         assertThat(environment.getBuildUrl())
-            .as("Build URL should match the value passed via -Dctrf.build.url")
-            .isEqualTo("http://system.example.com/build/");
+            .as("Build URL should follow the pattern https://github.com/alexshamrai/junit-ctrf-extension/actions/runs/ + number")
+            .matches("https://github\\.com/alexshamrai/junit-ctrf-extension/actions/runs/\\d+");
     }
 
     @Test


### PR DESCRIPTION
Updated test assertions to validate numeric and URL patterns for build parameters. Modified GitHub Actions workflow to dynamically set build number and URL using GitHub context variables. Enhanced the documentation to explain how to replicate CI conditions locally.