### PR TITLE
feat: automate Maven Central release process

### DIFF
--- a/.github/workflows/publish-maven-central.yml
+++ b/.github/workflows/publish-maven-central.yml
@@ -1,0 +1,152 @@
+name: Publish to Maven Central
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to publish (e.g., 0.4.0)'
+        required: true
+        type: string
+      nextVersion:
+        description: 'Next development version (e.g., 0.5.0-SNAPSHOT, leave empty to auto-increment)'
+        required: false
+        type: string
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v5
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v5
+
+      - name: Validate and calculate versions
+        id: versions
+        run: |
+          if [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
+            RELEASE_VERSION="${{ github.event.inputs.version }}"
+            NEXT_VERSION="${{ github.event.inputs.nextVersion }}"
+          else
+            RELEASE_VERSION="${GITHUB_REF#refs/tags/v}"
+            NEXT_VERSION=""
+          fi
+          
+          echo "Publishing version: $RELEASE_VERSION"
+          echo "RELEASE_VERSION=$RELEASE_VERSION" >> $GITHUB_ENV
+          echo "RELEASE_VERSION=$RELEASE_VERSION" >> $GITHUB_OUTPUT
+          
+          # Calculate next version if not provided
+          if [ -z "$NEXT_VERSION" ]; then
+            # Auto-increment minor version and add -SNAPSHOT
+            MAJOR=$(echo $RELEASE_VERSION | cut -d. -f1)
+            MINOR=$(echo $RELEASE_VERSION | cut -d. -f2)
+            PATCH=$(echo $RELEASE_VERSION | cut -d. -f3)
+            NEXT_MINOR=$((MINOR + 1))
+            NEXT_VERSION="${MAJOR}.${NEXT_MINOR}.0-SNAPSHOT"
+          fi
+          
+          echo "Next development version: $NEXT_VERSION"
+          echo "NEXT_VERSION=$NEXT_VERSION" >> $GITHUB_ENV
+          echo "NEXT_VERSION=$NEXT_VERSION" >> $GITHUB_OUTPUT
+
+      - name: Build and publish to Maven Central
+        env:
+          ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
+          ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
+          ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.GPG_PRIVATE_KEY }}
+          ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.GPG_PASSPHRASE }}
+        run: |
+          ./gradlew publishAllPublicationsToMavenCentralRepository --no-daemon --stacktrace
+
+      - name: Publish release summary
+        run: |
+          echo "✅ Successfully published version ${{ env.RELEASE_VERSION }} to Maven Central" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Artifact Details:**" >> $GITHUB_STEP_SUMMARY
+          echo "- Group: io.github.alexshamrai" >> $GITHUB_STEP_SUMMARY
+          echo "- Artifact: junit-ctrf-reporter" >> $GITHUB_STEP_SUMMARY
+          echo "- Version: ${{ env.RELEASE_VERSION }}" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "The artifact will be available at:" >> $GITHUB_STEP_SUMMARY
+          echo "https://repo1.maven.org/maven2/io/github/alexshamrai/junit-ctrf-reporter/${{ env.RELEASE_VERSION }}/" >> $GITHUB_STEP_SUMMARY
+
+      - name: Create branch for version update
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          
+          BRANCH_NAME="chore/update-version-after-${{ env.RELEASE_VERSION }}"
+          git checkout -b $BRANCH_NAME
+          echo "BRANCH_NAME=$BRANCH_NAME" >> $GITHUB_ENV
+
+      - name: Update version in build.gradle
+        run: |
+          # Update releaseVersion to the just-released version
+          sed -i "s/releaseVersion = '.*'/releaseVersion = '${{ env.RELEASE_VERSION }}'/" build.gradle
+          
+          # Update projectVersion to next development version
+          sed -i "s/projectVersion = '.*'/projectVersion = '${{ env.NEXT_VERSION }}'/" build.gradle
+          
+          cat build.gradle | grep -E "(releaseVersion|projectVersion)" || true
+
+      - name: Update version in README.md
+        run: |
+          # Update Maven dependency version
+          sed -i "s|junit-ctrf-reporter:[0-9.]*|junit-ctrf-reporter:${{ env.RELEASE_VERSION }}|g" README.md
+          
+          # Update Gradle dependency version
+          sed -i "s|implementation 'io.github.alexshamrai:junit-ctrf-reporter:[0-9.]*'|implementation 'io.github.alexshamrai:junit-ctrf-reporter:${{ env.RELEASE_VERSION }}'|" README.md
+          
+          cat README.md | grep "junit-ctrf-reporter:" || true
+
+      - name: Commit and push changes
+        run: |
+          git add build.gradle README.md
+          git commit -m "chore: update versions after ${{ env.RELEASE_VERSION }} release
+          
+          - Set releaseVersion to ${{ env.RELEASE_VERSION }}
+          - Set projectVersion to ${{ env.NEXT_VERSION }}
+          - Update README.md with latest version"
+          
+          git push origin ${{ env.BRANCH_NAME }}
+
+      - name: Create Pull Request
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh pr create \
+            --title "chore: Update versions after ${{ env.RELEASE_VERSION }} release" \
+            --body "This PR updates the version numbers after the successful release of version ${{ env.RELEASE_VERSION }}.
+          
+          ## Changes
+          
+          - ✅ Published version ${{ env.RELEASE_VERSION }} to Maven Central
+          - 📝 Updated \`releaseVersion\` in \`build.gradle\` to \`${{ env.RELEASE_VERSION }}\`
+          - 📝 Updated \`projectVersion\` in \`build.gradle\` to \`${{ env.NEXT_VERSION }}\`
+          - 📝 Updated dependency versions in \`README.md\` to \`${{ env.RELEASE_VERSION }}\`
+          
+          ## Maven Central
+          
+          The artifact will be available at:
+          https://repo1.maven.org/maven2/io/github/alexshamrai/junit-ctrf-reporter/${{ env.RELEASE_VERSION }}/
+          
+          _This PR was automatically created by the release workflow._" \
+            --base main \
+            --head ${{ env.BRANCH_NAME }}

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -62,3 +62,60 @@ This section is for maintainers who have permission to release new versions:
 2. Update documentation
 3. Create a new release tag
 4. Deploy to Maven Central
+
+## Automated Release to Maven Central
+
+This project uses GitHub Actions to automatically publish releases to Maven Central. The release process is fully
+automated and can be triggered either by pushing a version tag or manually through the GitHub Actions UI.
+
+### Triggering a Release
+
+There are two ways to trigger an automated release:
+
+#### Option 1: Push a Version Tag (Recommended)
+
+```bash
+# Create and push a version tag
+git tag v0.4.0
+git push origin v0.4.0
+```
+
+The workflow will automatically:
+1. Extract the version from the tag (e.g., `v0.4.0` → `0.4.0`)
+2. Build the project
+3. Sign the artifacts with your GPG key
+4. Publish to Maven Central
+
+#### Option 2: Manual Dispatch
+
+1. Go to the **Actions** tab in your GitHub repository
+2. Select the **"Publish to Maven Central"** workflow
+3. Click **"Run workflow"**
+4. Enter the version number (e.g., `0.4.0`)
+5. Click **"Run workflow"**
+
+### Post-Release Steps
+
+After the workflow completes successfully:
+
+1. **Verify the publication**: Check the workflow summary for the artifact URL
+2. **Wait for synchronization**: It may take 15-30 minutes for the artifact to appear on Maven Central
+3. **Update version numbers**: Update `projectVersion` and `releaseVersion` in `build.gradle` for the next development cycle
+4. **Create a GitHub Release** (optional): Document the changes in a GitHub release
+
+### Troubleshooting
+
+**Workflow fails during signing:**
+- Verify that `GPG_PRIVATE_KEY` includes the complete ASCII-armored key with BEGIN/END lines
+- Ensure `GPG_PASSPHRASE` matches the passphrase used when creating the key
+- Check that your public key was successfully uploaded to a key server
+
+**Workflow fails during publication:**
+- Verify your Maven Central credentials are correct
+- Ensure you have claimed your namespace on Maven Central (e.g., `io.github.alexshamrai`)
+- Check that the version number doesn't already exist
+
+**Artifact doesn't appear on Maven Central:**
+- Wait 15-30 minutes for synchronization
+- Check [Maven Central Search](https://search.maven.org/) for your artifact
+- Verify the workflow completed successfully without errors

--- a/build.gradle
+++ b/build.gradle
@@ -96,3 +96,13 @@ mavenPublishing {
         }
     }
 }
+// Enable in-memory GPG signing for CI/CD environments
+afterEvaluate {
+    signing {
+        def signingKey = findProperty("signingInMemoryKey")
+        def signingPassword = findProperty("signingInMemoryKeyPassword")
+        if (signingKey && signingPassword) {
+            useInMemoryPgpKeys(signingKey, signingPassword)
+        }
+    }
+}


### PR DESCRIPTION
Introduce a GitHub Actions workflow for automated releases to Maven Central. Added support for in-memory GPG signing to streamline CI/CD workflows and documented the release process in the README.